### PR TITLE
Fix missing key prop

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "ra-compact-ui": "file:../..",
     "ra-data-fakerest": "^3.9.3",
     "react": "^17.0.1",
     "react-admin": "^3.11.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         "build": "rimraf ./dist && yarn babel-transpile",
         "prepare": "yarn build",
         "prettier": "prettier  --config prettier.config.js --write ./src/",
-        "start-demo": "cd examples/demo && yarn start"
+        "start-demo": "cd examples/demo && rm -rf node_modules/ra-compact-ui && yarn --check-files && yarn start"
     },
     "repository": "https://github.com/ValentinnDimitroff/ra-compact-ui.git",
     "author": "Valentin Dimitroff",

--- a/src/core/recursiveMethods.js
+++ b/src/core/recursiveMethods.js
@@ -22,11 +22,13 @@ const recursivelyFindRealChildren = ({ child, ...props }) => {
         return cloneElement(child, {
             children:
                 Children.count(child.props.children) > 1
-                    ? child.props.children
-                        .map((innerChild) => recursivelyFindRealChildren({
+                    ? Children.map(
+                        child.props.children,
+                        (innerChild) => recursivelyFindRealChildren({
                             child: innerChild,
                             ...props,
-                        }))
+                        }),
+                    )
                     : recursivelyFindRealChildren({
                         child: child.props.children,
                         ...props,
@@ -35,5 +37,5 @@ const recursivelyFindRealChildren = ({ child, ...props }) => {
     }
 
     // Non-layout element found - recursion's bottom
-    return renderFnc(child, props);
+    return renderFnc(child);
 };


### PR DESCRIPTION
Fixes https://github.com/ValentinnDimitroff/ra-compact-ui/issues/14 .

Currently our code maps children using `Array.prototype.map` . Because of that, `key` is not passed to mapped children, and this raises React warning about missing "key" parameter, which might also impact rendering performance.

If we map those children using `React.Children.map`, then that problem is gone. ( https://stackoverflow.com/a/50303840/1860149 )