### PR TITLE
Remove basePath & record property

### DIFF
--- a/src/details/CompactShowLayout.jsx
+++ b/src/details/CompactShowLayout.jsx
@@ -7,7 +7,6 @@ import { cloneRecursively, getComponentsNames, isLayoutComponent } from '../core
 const sanitizeRestProps = ({
     children,
     className,
-    record,
     resource,
     version,
     initialValues,
@@ -19,7 +18,6 @@ const CompactShowLayout = ({
     layoutComponents,
     className,
     children,
-    record,
     resource,
     version,
     ...rest
@@ -35,7 +33,6 @@ const CompactShowLayout = ({
                     (x) => (
                         <RaField
                             field={x}
-                            record={record}
                             resource={resource}
                         />
                     )

--- a/src/details/CompactShowLayout.jsx
+++ b/src/details/CompactShowLayout.jsx
@@ -9,7 +9,6 @@ const sanitizeRestProps = ({
     className,
     record,
     resource,
-    basePath,
     version,
     initialValues,
     translate,
@@ -18,7 +17,6 @@ const sanitizeRestProps = ({
 
 const CompactShowLayout = ({
     layoutComponents,
-    basePath,
     className,
     children,
     record,
@@ -37,7 +35,6 @@ const CompactShowLayout = ({
                     (x) => (
                         <RaField
                             field={x}
-                            basePath={basePath}
                             record={record}
                             resource={resource}
                         />
@@ -48,7 +45,6 @@ const CompactShowLayout = ({
     )
 }
 CompactShowLayout.propTypes = {
-    basePath: PropTypes.string,
     record: PropTypes.object,
     resource: PropTypes.string,
     version: PropTypes.number,

--- a/src/details/CompactShowLayout.test.js
+++ b/src/details/CompactShowLayout.test.js
@@ -26,7 +26,6 @@ test('renders correctly', async () => {
         ),
         record,
         resource: 'users',
-        basePath: '/users',
         version: 1,
     }
 

--- a/src/details/RaField.jsx
+++ b/src/details/RaField.jsx
@@ -5,7 +5,7 @@ import { Labeled } from 'react-admin'
 
 const sanitizeRestProps = ({ layoutComponentName, ...rest }) => rest
 
-const RaField = ({ field, record, resource, ...props }) => (
+const RaField = ({ field, resource, ...props }) => (
     <div
         key={field.props.source}
         className={classnames(`ra-field ra-field-${field.props.source}`, field.props.className)}
@@ -13,7 +13,6 @@ const RaField = ({ field, record, resource, ...props }) => (
     >
         {field.props.label !== false ? (
             <Labeled
-                record={record}
                 resource={resource}
                 label={field.props.label}
                 source={field.props.source}
@@ -25,7 +24,6 @@ const RaField = ({ field, record, resource, ...props }) => (
             field
         ) : (
             React.cloneElement(field, {
-                record,
                 resource,
             })
         )}

--- a/src/details/RaField.jsx
+++ b/src/details/RaField.jsx
@@ -5,7 +5,7 @@ import { Labeled } from 'react-admin'
 
 const sanitizeRestProps = ({ layoutComponentName, ...rest }) => rest
 
-const RaField = ({ field, record, resource, basePath, ...props }) => (
+const RaField = ({ field, record, resource, ...props }) => (
     <div
         key={field.props.source}
         className={classnames(`ra-field ra-field-${field.props.source}`, field.props.className)}
@@ -15,7 +15,6 @@ const RaField = ({ field, record, resource, basePath, ...props }) => (
             <Labeled
                 record={record}
                 resource={resource}
-                basePath={basePath}
                 label={field.props.label}
                 source={field.props.source}
                 disabled={false}
@@ -28,14 +27,12 @@ const RaField = ({ field, record, resource, basePath, ...props }) => (
             React.cloneElement(field, {
                 record,
                 resource,
-                basePath,
             })
         )}
     </div>
 )
 
 RaField.propTypes = {
-    basePath: PropTypes.string,
     record: PropTypes.object,
     resource: PropTypes.string,
     field: PropTypes.object,

--- a/src/edit/CompactForm.jsx
+++ b/src/edit/CompactForm.jsx
@@ -29,7 +29,6 @@ CompactForm.propTypes = {
 }
 
 const CompactFormView = ({
-    basePath,
     children,
     className,
     component: Component,
@@ -62,7 +61,6 @@ const CompactFormView = ({
                         (x) => (
                             <FormInput
                                 input={x}
-                                basePath={basePath}
                                 record={record}
                                 resource={resource}
                                 variant={x.props.variant || variant}
@@ -74,7 +72,6 @@ const CompactFormView = ({
             </Component>
             {toolbar &&
                 cloneElement(toolbar, {
-                    basePath,
                     handleSubmitWithRedirect,
                     handleSubmit,
                     invalid,
@@ -92,7 +89,6 @@ const CompactFormView = ({
 }
 
 CompactFormView.propTypes = {
-    basePath: PropTypes.string,
     children: PropTypes.node,
     className: PropTypes.string,
     handleSubmit: PropTypes.func, // passed by react-final-form


### PR DESCRIPTION
The basePath is removed in Version 4.x from react-admin and not needed anymore. Without this changed some warnings are produced.

https://marmelab.com/react-admin/Upgrade.html#removed-the-basepath-prop

Remove the record property, which is also not needed anymore since every component should get the record via context. 