### PR TITLE
feat: Add CompactChipField component

### DIFF
--- a/examples/demo/src/components/projects/ProjectShow.tsx
+++ b/examples/demo/src/components/projects/ProjectShow.tsx
@@ -3,13 +3,16 @@ import {
     SimpleShowLayout,
     ReferenceField,
     TextField,
-    ChipField,
     DateField,
     ArrayField,
     Datagrid,
     SingleFieldList,
 } from 'react-admin'
 import Box from '@mui/material/Box'
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty'
+import AutorenewIcon from '@mui/icons-material/Autorenew'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import { CompactChipField } from 'ra-compact-ui'
 import { UserChipField } from './UserChipField'
 
 const ProjectShow = () => {
@@ -36,7 +39,14 @@ const ProjectShow = () => {
                             >
                                 <TextField source="name" />
                             </ReferenceField>
-                            <ChipField source="progressStatus" label="Progress Status" />
+                            <CompactChipField
+                                source="progressStatus"
+                                options={{
+                                    Pending: { color: 'warning', icon: <HourglassEmptyIcon /> },
+                                    InProgress: { color: 'info', icon: <AutorenewIcon /> },
+                                    Done: { color: 'success', icon: <CheckCircleIcon /> },
+                                }}
+                            />
                             <TextField source="priority" />
                         </Box>
                         <Box flex="0 0 100%" display="flex" justifyContent="space-between">

--- a/src/fields/CompactChipField.tsx
+++ b/src/fields/CompactChipField.tsx
@@ -85,7 +85,11 @@ export const CompactChipField = ({
             variant={chipVariant}
             color={isPalette && variant !== 'light' ? (color as PaletteColor) : undefined}
             icon={optionValue?.icon}
-            sx={((theme: Theme) => ({ ...buildSx(theme), ...(sx as object) })) as any}
+            sx={((theme: Theme) => ({
+                ...buildSx(theme),
+                '& .MuiChip-icon': { color: 'inherit' },
+                ...(sx as object),
+            })) as any}
         />
     )
 }

--- a/src/fields/CompactChipField.tsx
+++ b/src/fields/CompactChipField.tsx
@@ -1,0 +1,91 @@
+import { alpha, SxProps, Theme } from '@mui/material'
+import { ReactElement } from 'react'
+import { ChipField, useRecordContext } from 'react-admin'
+
+type PaletteColor = 'default' | 'primary' | 'secondary' | 'error' | 'info' | 'success' | 'warning'
+
+const PALETTE_COLORS = new Set<string>([
+    'default',
+    'primary',
+    'secondary',
+    'error',
+    'info',
+    'success',
+    'warning',
+])
+
+interface ChipOption {
+    color?: PaletteColor | (string & {})
+    icon?: ReactElement
+}
+
+interface CompactChipFieldProps {
+    source: string
+    options: Record<string, ChipOption>
+    variant?: 'filled' | 'outlined' | 'light'
+    size?: 'small' | 'medium'
+    empty?: ReactElement | null
+    sx?: SxProps<Theme>
+}
+
+export const CompactChipField = ({
+    source,
+    options,
+    variant = 'light',
+    size = 'small',
+    empty = null,
+    sx,
+}: CompactChipFieldProps) => {
+    const record = useRecordContext()
+    if (!record) return null
+
+    const value = record[source] as string
+    if (!value) return empty
+
+    const optionValue = options[value]
+    const color = optionValue?.color
+    const isPalette = color && PALETTE_COLORS.has(color)
+
+    const chipVariant = variant === 'light' ? 'filled' : variant
+
+    const buildSx = (theme: Theme) => {
+        if (!color) return {}
+
+        if (isPalette && variant === 'light') {
+            const paletteColor = theme.palette[color as Exclude<PaletteColor, 'default'>]
+            if (paletteColor) {
+                return {
+                    backgroundColor: alpha(paletteColor.main, 0.12),
+                    color: paletteColor.main,
+                }
+            }
+        }
+
+        if (!isPalette) {
+            if (variant === 'light') {
+                return {
+                    backgroundColor: alpha(color, 0.12),
+                    color,
+                }
+            }
+            return {
+                backgroundColor: variant === 'filled' ? color : 'transparent',
+                color: variant === 'filled' ? '#fff' : color,
+                borderColor: variant === 'outlined' ? color : undefined,
+            }
+        }
+
+        return {}
+    }
+
+    return (
+        <ChipField
+            source={source}
+            size={size}
+            variant={chipVariant}
+            color={isPalette && variant !== 'light' ? (color as PaletteColor) : undefined}
+            icon={optionValue?.icon}
+            sx={((theme: Theme) => ({ ...buildSx(theme), ...(sx as object) })) as any}
+        />
+    )
+}

--- a/src/fields/index.ts
+++ b/src/fields/index.ts
@@ -1,3 +1,4 @@
 export { AvatarField } from './AvatarField'
 export { ChipFieldArray } from './ChipFieldArray'
+export { CompactChipField } from './CompactChipField'
 export { FullNameField } from './FullNameField'


### PR DESCRIPTION
Introduce easily configurable status showing `ChipField` accepting a map of possible values with their color and icons and rendering the proper style based on the `source` property's record value.