### PR TITLE
feat: Allow deep field sources on AvatarField

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ import { AvatarField } from 'ra-compact-ui'
 <AvatarField source="avatar_url" altSource="full_name" size="50" />
 ```
 
-### ChipFieldArray
+### ChipArrayField
 
 Renders an array field as a list of MUI Chips.
 
 ```tsx
-import { ChipFieldArray } from 'ra-compact-ui'
+import { ChipArrayField } from 'ra-compact-ui'
 
-<ChipFieldArray source="tags" />
+<ChipArrayField source="tags" />
 ```
 
 ### FullNameField

--- a/src/details/ShowSplitter.tsx
+++ b/src/details/ShowSplitter.tsx
@@ -12,9 +12,9 @@ interface SideProps {
 }
 
 interface ShowSplitterProps {
-    leftSide: ReactElement
+    leftSide?: ReactElement
     leftSideProps?: SideProps
-    rightSide: ReactElement
+    rightSide?: ReactElement
     rightSideProps?: SideProps
 }
 
@@ -46,12 +46,16 @@ const ShowSplitter = ({
 
     return (
         <Grid container spacing={4}>
-            <Grid item {...restLeftProps}>
-                <LeftContainer>{cloneElement(leftSide, props)}</LeftContainer>
-            </Grid>
-            <Grid item {...restRightProps}>
-                <RightContainer>{cloneElement(rightSide, props)}</RightContainer>
-            </Grid>
+            {leftSide && (
+                <Grid item {...restLeftProps}>
+                    <LeftContainer>{cloneElement(leftSide, props)}</LeftContainer>
+                </Grid>
+            )}
+            {rightSide && (
+                <Grid item {...restRightProps}>
+                    <RightContainer>{cloneElement(rightSide, props)}</RightContainer>
+                </Grid>
+            )}
         </Grid>
     )
 }

--- a/src/fields/AvatarField.tsx
+++ b/src/fields/AvatarField.tsx
@@ -1,6 +1,6 @@
 import Avatar from '@mui/material/Avatar'
 import { SxProps, Theme } from '@mui/material/styles'
-import { useRecordContext } from 'react-admin'
+import { useFieldValue } from 'react-admin'
 
 const getOptimizedSrc = (url: string, size: string) => `${url}?size=${size}x${size}`
 
@@ -10,6 +10,7 @@ interface AvatarFieldProps {
     size?: string
     fallback?: string
     sx?: SxProps<Theme>
+    record?: Record<string, unknown>
 }
 
 export const AvatarField = ({
@@ -18,18 +19,22 @@ export const AvatarField = ({
     size = '25',
     fallback,
     sx,
+    record,
 }: AvatarFieldProps) => {
-    const record = useRecordContext()
+    const imageSource = useFieldValue({ source, record })
+    const altText = useFieldValue({ source: altSource ?? '', record, defaultValue: '' })
 
-    return record ? (
+    if (!imageSource && !fallback) return null
+
+    return (
         <Avatar
-            src={(record[source] && getOptimizedSrc(record[source] as string, size)) || fallback}
+            src={(imageSource && getOptimizedSrc(imageSource, size)) || fallback}
             sx={{
                 width: `${size}px`,
                 height: `${size}px`,
                 ...sx,
             }}
-            alt={altSource ? (record[altSource] as string) : undefined}
+            alt={altText}
         />
-    ) : null
+    )
 }

--- a/src/fields/ChipArrayField.tsx
+++ b/src/fields/ChipArrayField.tsx
@@ -4,11 +4,12 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 import { Theme } from '@mui/material/styles'
 import { useRecordContext } from 'react-admin'
 
-interface ChipFieldArrayProps {
+interface ChipArrayFieldProps {
     source: string
+    label?: string
 }
 
-export const ChipFieldArray = ({ source }: ChipFieldArrayProps) => {
+export const ChipArrayField = ({ source }: ChipArrayFieldProps) => {
     const isSmall = useMediaQuery((theme: Theme) => theme.breakpoints.down('sm'))
     const record = useRecordContext()
 

--- a/src/fields/index.ts
+++ b/src/fields/index.ts
@@ -1,4 +1,4 @@
 export { AvatarField } from './AvatarField'
-export { ChipFieldArray } from './ChipFieldArray'
+export { ChipArrayField } from './ChipArrayField'
 export { CompactChipField } from './CompactChipField'
 export { FullNameField } from './FullNameField'


### PR DESCRIPTION
Using react-admin's native `useFieldValue` to allow deep field sources like values like `user.picture`  work out of the box.



feat: Make both sides of the `ShowSplitter` component optional
feat: Rename ChipFieldArray to ChipArrayField for consistency